### PR TITLE
Gracefully handle null and undefined values

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,8 @@
 function validate(vin) {
+  if (!vin) {
+    return false;
+  }
+
   vin = vin.toLowerCase();
   if (!/^[a-hj-npr-z0-9]{8}[0-9xX][a-hj-npr-z0-9]{8}$/.test(vin)) {
     return false;

--- a/test/vin.js
+++ b/test/vin.js
@@ -143,3 +143,27 @@ describe('Given a VIN with a correct check digit', function() {
     });
   });
 });
+
+describe('Given null value', function() {
+  var vin = null;
+
+  describe('When the VIN is validated', function() {
+    var valid;
+    beforeEach(function() { valid = vinValidator.validate(vin); })
+
+    it('Then it should fail', function() {
+      expect(valid).to.be.false;
+    });
+  });
+});
+
+describe('Given undefined', function() {
+  describe('When the VIN is validated', function() {
+    var valid;
+    beforeEach(function() { valid = vinValidator.validate(); })
+
+    it('Then it should fail', function() {
+      expect(valid).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
In the current implementation, if one passes `null` or `undefined` to the validator, it fails with an exception ` TypeError: Cannot read property 'toLowerCase' of null/undefined`. This PR fixes this by adjusting the validator to return `false` instead